### PR TITLE
Improve `LoxFunction` performances

### DIFF
--- a/go/pkg/runtime/interpreter.go
+++ b/go/pkg/runtime/interpreter.go
@@ -31,6 +31,7 @@ func NewInterpreter(outputStream io.Writer, errorFormatter loxerror.ErrorFormatt
 		ErrorFormatter:  errorFormatter,
 		OutputStream:    outputStream,
 		hasReturned:     false,
+		frameNumber:     0,
 		globals:         NewEnvironment(),
 		environment:     nil,
 		locals:          make(map[ast.Expression]int),


### PR DESCRIPTION
`LoxFunction` implementation relies on `panic()` to unwind the stack frame to get back to the call-site.
It makes function calls really expensive